### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 ukui-interface (1.0.0-2) UNRELEASED; urgency=low
 
   * Set upstream metadata fields: Bug-Database, Bug-Submit.
+  * Update standards version to 4.5.0, no changes needed.
 
  -- Debian Janitor <janitor@jelmer.uk>  Thu, 11 Jun 2020 02:24:40 -0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ukui-interface (1.0.0-2) UNRELEASED; urgency=low
+
+  * Set upstream metadata fields: Bug-Database, Bug-Submit.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Thu, 11 Jun 2020 02:24:40 -0000
+
 ukui-interface (1.0.0-1) unstable; urgency=medium
 
   * Initial release. (Closes: #941256)

--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Build-Depends: debhelper-compat (=12),
                automake,
                libtool,
                qtbase5-dev
-Standards-Version: 4.4.1
+Standards-Version: 4.5.0
 Rules-Requires-Root: no
 Homepage: https://github.com/ukui/ukui-interface
 Vcs-Browser: https://github.com/ukui/ukui-interface

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,3 @@
+---
+Bug-Database: https://github.com/ukui/ukui-interface/issues
+Bug-Submit: https://github.com/ukui/ukui-interface/issues/new


### PR DESCRIPTION
Fix some issues reported by lintian
* Set upstream metadata fields: Bug-Database, Bug-Submit. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing.html), [upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking.html))
* Update standards version to 4.5.0, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version.html))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/ukui-interface/d0344999-c7c9-46ed-b2f4-034ffbc98c15.


These changes affect the binary packages; see the
[debdiff](https://janitor.debian.net/api/run/d0344999-c7c9-46ed-b2f4-034ffbc98c15/debdiff?filter_boring=1)


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/d0344999-c7c9-46ed-b2f4-034ffbc98c15/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/d0344999-c7c9-46ed-b2f4-034ffbc98c15/diffoscope)).
