### PR TITLE
Apply hints suggested by the multi-arch hinter

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,24 @@ ukui-interface (1.0.0-2) UNRELEASED; urgency=low
 
   * Set upstream metadata fields: Bug-Database, Bug-Submit.
   * Update standards version to 4.5.0, no changes needed.
+  * Apply multi-arch hints.
+    + libukui-backgroundclient-dev, libukui-backgroundclient0,
+      libukui-datesetting-dev, libukui-datesetting0,
+      libukui-defaultprograms-dev, libukui-defaultprograms0,
+      libukui-desktopclient-dev, libukui-desktopclient0, libukui-fontclient-dev,
+      libukui-fontclient0, libukui-gsettings-dev, libukui-gsettings0,
+      libukui-interfaceclient-dev, libukui-interfaceclient0,
+      libukui-keyboardclient-dev, libukui-keyboardclient0,
+      libukui-marcogeneralclient-dev, libukui-marcogeneralclient0,
+      libukui-mouseclient-dev, libukui-mouseclient0, libukui-network-dev,
+      libukui-network0, libukui-powerclient-dev, libukui-powerclient0,
+      libukui-print-dev, libukui-print0, libukui-screensaverclient-dev,
+      libukui-screensaverclient0, libukui-sessionclient-dev,
+      libukui-sessionclient0, libukui-subversion-dev, libukui-subversion0,
+      libukui-sysinfo-dev, libukui-sysinfo0, libukui-touchpadclient-dev,
+      libukui-touchpadclient0, libukui-usersetting-dev, libukui-usersetting0,
+      libukui-xkbgeneralclient-dev, libukui-xkbgeneralclient0: Add Multi-Arch:
+      same.
 
  -- Debian Janitor <janitor@jelmer.uk>  Thu, 11 Jun 2020 02:24:40 -0000
 

--- a/debian/control
+++ b/debian/control
@@ -18,6 +18,7 @@ Vcs-Git: https://github.com/ukui/ukui-interface.git
 Package: libukui-print0
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
+Multi-Arch: same
 Description: print module
  UKUI interface provides the interface for system configuration
  and related libraries.
@@ -30,6 +31,7 @@ Section: libdevel
 Depends: ${shlibs:Depends},
          ${misc:Depends},
          libukui-print0 (= ${binary:Version})
+Multi-Arch: same
 Description: print interface
  UKUI interface provides the interface for system configuration
  and related libraries.
@@ -39,6 +41,7 @@ Description: print interface
 Package: libukui-gsettings0
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
+Multi-Arch: same
 Description: application settings module
  UKUI interface provides the interface for system configuration
  and related libraries.
@@ -51,6 +54,7 @@ Section: libdevel
 Depends: ${shlibs:Depends},
 	${misc:Depends},
 	libukui-gsettings0 (= ${binary:Version})
+Multi-Arch: same
 Description: application settings interface
  UKUI interface provides the interface for system configuration
  and related libraries.
@@ -76,6 +80,7 @@ Depends: ${shlibs:Depends},
 	libukui-print0 (= ${binary:Version}),
 	libukui-gsettings0 (= ${binary:Version}),
 	ukui-backgroundserver (= ${binary:Version})
+Multi-Arch: same
 Description: background settings module
  UKUI interface provides the interface for system configuration
  and related libraries.
@@ -88,6 +93,7 @@ Section: libdevel
 Depends: ${shlibs:Depends},
 	${misc:Depends},
 	libukui-backgroundclient0 (= ${binary:Version})
+Multi-Arch: same
 Description: background settings interfaces
  UKUI interface provides the interface for system configuration
  and related libraries.
@@ -97,6 +103,7 @@ Description: background settings interfaces
 Package: libukui-datesetting0
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
+Multi-Arch: same
 Description: date settings module
  UKUI interface provides the interface for system configuration
  and related libraries.
@@ -109,6 +116,7 @@ Section: libdevel
 Depends: ${shlibs:Depends},
         ${misc:Depends},
         libukui-datesetting0 (= ${binary:Version})
+Multi-Arch: same
 Description: date settings interfaces
  UKUI interface provides the interface for system configuration
  and related libraries.
@@ -118,6 +126,7 @@ Description: date settings interfaces
 Package: libukui-defaultprograms0
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
+Multi-Arch: same
 Description: default programs settings module
  UKUI interface provides the interface for system configuration
  and related libraries.
@@ -130,6 +139,7 @@ Section: libdevel
 Depends: ${shlibs:Depends},
         ${misc:Depends},
         libukui-defaultprograms0 (= ${binary:Version})
+Multi-Arch: same
 Description: default programs settings interfaces
  UKUI interface provides the interface for system configuration
  and related libraries.
@@ -155,6 +165,7 @@ Depends: ${shlibs:Depends},
 	libukui-print0 (= ${binary:Version}),
 	libukui-gsettings0 (= ${binary:Version}),
 	ukui-desktopserver (= ${binary:Version})
+Multi-Arch: same
 Description: desktop settings module
  UKUI interface provides the interface for system configuration
  and related libraries.
@@ -167,6 +178,7 @@ Section: libdevel
 Depends: ${shlibs:Depends},
         ${misc:Depends},
         libukui-desktopclient0 (= ${binary:Version})
+Multi-Arch: same
 Description: desktop settings interfaces
  UKUI interface provides the interface for system configuration
  and related libraries.
@@ -192,6 +204,7 @@ Depends: ${shlibs:Depends},
 	libukui-print0 (= ${binary:Version}),
 	libukui-gsettings0 (= ${binary:Version}),
 	ukui-fontserver (= ${binary:Version})
+Multi-Arch: same
 Description: font settings module
  UKUI interface provides the interface for system configuration
  and related libraries.
@@ -204,6 +217,7 @@ Section: libdevel
 Depends: ${shlibs:Depends},
         ${misc:Depends},
         libukui-fontclient0 (= ${binary:Version})
+Multi-Arch: same
 Description: font settings interfaces
  UKUI interface provides the interface for system configuration
  and related libraries.
@@ -229,6 +243,7 @@ Depends: ${shlibs:Depends},
 	libukui-print0 (= ${binary:Version}),
 	libukui-gsettings0 (= ${binary:Version}),
 	ukui-interfaceserver (= ${binary:Version})
+Multi-Arch: same
 Description: interface settings module
  UKUI interface provides the interface for system configuration
  and related libraries.
@@ -241,6 +256,7 @@ Section: libdevel
 Depends: ${shlibs:Depends},
         ${misc:Depends},
         libukui-interfaceclient0 (= ${binary:Version})
+Multi-Arch: same
 Description: interface settings interfaces
  UKUI interface provides the interface for system configuration
  and related libraries.
@@ -266,6 +282,7 @@ Depends: ${shlibs:Depends},
 	libukui-print0 (= ${binary:Version}),
 	libukui-gsettings0 (= ${binary:Version}),
 	ukui-keyboardserver (= ${binary:Version})
+Multi-Arch: same
 Description: keyboard settings module
  UKUI interface provides the interface for system configuration
  and related libraries.
@@ -278,6 +295,7 @@ Section: libdevel
 Depends: ${shlibs:Depends},
         ${misc:Depends},
         libukui-keyboardclient0 (= ${binary:Version})
+Multi-Arch: same
 Description: keyboard settings interfaces
  UKUI interface provides the interface for system configuration
  and related libraries.
@@ -298,6 +316,7 @@ Architecture: any
 Depends: ${shlibs:Depends},
 	${misc:Depends},
 	ukui-marcogeneralserver (= ${binary:Version})
+Multi-Arch: same
 Description: marcogeneral settings module
  UKUI interface provides the interface for system configuration
  and related libraries.
@@ -310,6 +329,7 @@ Section: libdevel
 Depends: ${shlibs:Depends},
         ${misc:Depends},
         libukui-marcogeneralclient0 (= ${binary:Version})
+Multi-Arch: same
 Description: marcogeneral settings interfaces
  UKUI interface provides the interface for system configuration
  and related libraries.
@@ -330,6 +350,7 @@ Architecture: any
 Depends: ${shlibs:Depends},
 	${misc:Depends},
 	ukui-mouseserver (= ${binary:Version})
+Multi-Arch: same
 Description: mouse settings module
  UKUI interface provides the interface for system configuration
  and related libraries.
@@ -342,6 +363,7 @@ Section: libdevel
 Depends: ${shlibs:Depends},
         ${misc:Depends},
         libukui-mouseclient0 (= ${binary:Version})
+Multi-Arch: same
 Description: mouse settings interfaces
  UKUI interface provides the interface for system configuration
  and related libraries.
@@ -351,6 +373,7 @@ Description: mouse settings interfaces
 Package: libukui-network0
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
+Multi-Arch: same
 Description: network settings module
  UKUI interface provides the interface for system configuration
  and related libraries.
@@ -363,6 +386,7 @@ Section: libdevel
 Depends: ${shlibs:Depends},
         ${misc:Depends},
         libukui-network0 (= ${binary:Version})
+Multi-Arch: same
 Description: network settings interfaces
  UKUI interface provides the interface for system configuration
  and related libraries.
@@ -388,6 +412,7 @@ Depends: ${shlibs:Depends},
 	libukui-print0 (= ${binary:Version}),
 	libukui-gsettings0 (= ${binary:Version}),
 	ukui-powerserver (= ${binary:Version})
+Multi-Arch: same
 Description: power settings module
  UKUI interface provides the interface for system configuration
  and related libraries.
@@ -400,6 +425,7 @@ Section: libdevel
 Depends: ${shlibs:Depends},
         ${misc:Depends},
         libukui-powerclient0 (= ${binary:Version})
+Multi-Arch: same
 Description: power settings interfaces
  UKUI interface provides the interface for system configuration
  and related libraries.
@@ -420,6 +446,7 @@ Architecture: any
 Depends: ${shlibs:Depends},
 	${misc:Depends},
 	ukui-screensaverserver (= ${binary:Version})
+Multi-Arch: same
 Description: screensaver settings module
  UKUI interface provides the interface for system configuration
  and related libraries.
@@ -432,6 +459,7 @@ Section: libdevel
 Depends: ${shlibs:Depends},
         ${misc:Depends},
         libukui-screensaverclient0 (= ${binary:Version})
+Multi-Arch: same
 Description: screensaver settings interfaces
  UKUI interface provides the interface for system configuration
  and related libraries.
@@ -452,6 +480,7 @@ Architecture: any
 Depends: ${shlibs:Depends},
 	${misc:Depends},
 	ukui-sessionserver (= ${binary:Version})
+Multi-Arch: same
 Description: session settings module
  UKUI interface provides the interface for system configuration
  and related libraries.
@@ -464,6 +493,7 @@ Section: libdevel
 Depends: ${shlibs:Depends},
         ${misc:Depends},
         libukui-sessionclient0 (= ${binary:Version})
+Multi-Arch: same
 Description: session settings interfaces
  UKUI interface provides the interface for system configuration
  and related libraries.
@@ -473,6 +503,7 @@ Description: session settings interfaces
 Package: libukui-subversion0
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
+Multi-Arch: same
 Description: Subversion check module
  UKUI interface provides the interface for system configuration
  and related libraries.
@@ -485,6 +516,7 @@ Section: libdevel
 Depends: ${shlibs:Depends},
         ${misc:Depends},
         libukui-subversion0 (= ${binary:Version})
+Multi-Arch: same
 Description: Subversion check interfaces
  UKUI interface provides the interface for system configuration
  and related libraries.
@@ -494,6 +526,7 @@ Description: Subversion check interfaces
 Package: libukui-sysinfo0
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
+Multi-Arch: same
 Description: system information gettings module
  UKUI interface provides the interface for system configuration
  and related libraries.
@@ -506,6 +539,7 @@ Section: libdevel
 Depends: ${shlibs:Depends},
         ${misc:Depends},
         libukui-sysinfo0 (= ${binary:Version})
+Multi-Arch: same
 Description: system information gettings interfaces
  UKUI interface provides the interface for system configuration
  and related libraries.
@@ -531,6 +565,7 @@ Depends: ${shlibs:Depends},
 	libukui-print0 (= ${binary:Version}),
 	libukui-gsettings0 (= ${binary:Version}),
 	ukui-touchpadserver (= ${binary:Version})
+Multi-Arch: same
 Description: touchpad settings module
  UKUI interface provides the interface for system configuration
  and related libraries.
@@ -543,6 +578,7 @@ Section: libdevel
 Depends: ${shlibs:Depends},
         ${misc:Depends},
         libukui-touchpadclient0 (= ${binary:Version})
+Multi-Arch: same
 Description: touchpad settings interfaces
  UKUI interface provides the interface for system configuration
  and related libraries.
@@ -552,6 +588,7 @@ Description: touchpad settings interfaces
 Package: libukui-usersetting0
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
+Multi-Arch: same
 Description: user settings module
  UKUI interface provides the interface for system configuration
  and related libraries.
@@ -564,6 +601,7 @@ Section: libdevel
 Depends: ${shlibs:Depends},
         ${misc:Depends},
         libukui-usersetting0 (= ${binary:Version})
+Multi-Arch: same
 Description: user settings interfaces
  UKUI interface provides the interface for system configuration
  and related libraries.
@@ -584,6 +622,7 @@ Architecture: any
 Depends: ${shlibs:Depends},
 	${misc:Depends},
 	ukui-xkbgeneralserver (= ${binary:Version})
+Multi-Arch: same
 Description: xkbgeneral settings module
  UKUI interface provides the interface for system configuration
  and related libraries.
@@ -596,6 +635,7 @@ Section: libdevel
 Depends: ${shlibs:Depends},
         ${misc:Depends},
         libukui-xkbgeneralclient0 (= ${binary:Version})
+Multi-Arch: same
 Description: xkbgeneral settings interfaces
  UKUI interface provides the interface for system configuration
  and related libraries.


### PR DESCRIPTION
Apply hints suggested by the multi-arch hinter.

* libukui-print0: Add Multi-Arch: same. This fixes: libukui-print0 could be marked Multi-Arch: same. ([ma-same](https://wiki.debian.org/MultiArch/Hints#ma-same))
* libukui-print-dev: Add Multi-Arch: same. This fixes: libukui-print-dev could be marked Multi-Arch: same. ([ma-same](https://wiki.debian.org/MultiArch/Hints#ma-same))
* libukui-gsettings0: Add Multi-Arch: same. This fixes: libukui-gsettings0 could be marked Multi-Arch: same. ([ma-same](https://wiki.debian.org/MultiArch/Hints#ma-same))
* libukui-gsettings-dev: Add Multi-Arch: same. This fixes: libukui-gsettings-dev could be marked Multi-Arch: same. ([ma-same](https://wiki.debian.org/MultiArch/Hints#ma-same))
* libukui-backgroundclient0: Add Multi-Arch: same. This fixes: libukui-backgroundclient0 could be marked Multi-Arch: same. ([ma-same](https://wiki.debian.org/MultiArch/Hints#ma-same))
* libukui-backgroundclient-dev: Add Multi-Arch: same. This fixes: libukui-backgroundclient-dev could be marked Multi-Arch: same. ([ma-same](https://wiki.debian.org/MultiArch/Hints#ma-same))
* libukui-datesetting0: Add Multi-Arch: same. This fixes: libukui-datesetting0 could be marked Multi-Arch: same. ([ma-same](https://wiki.debian.org/MultiArch/Hints#ma-same))
* libukui-datesetting-dev: Add Multi-Arch: same. This fixes: libukui-datesetting-dev could be marked Multi-Arch: same. ([ma-same](https://wiki.debian.org/MultiArch/Hints#ma-same))
* libukui-defaultprograms0: Add Multi-Arch: same. This fixes: libukui-defaultprograms0 could be marked Multi-Arch: same. ([ma-same](https://wiki.debian.org/MultiArch/Hints#ma-same))
* libukui-defaultprograms-dev: Add Multi-Arch: same. This fixes: libukui-defaultprograms-dev could be marked Multi-Arch: same. ([ma-same](https://wiki.debian.org/MultiArch/Hints#ma-same))
* libukui-desktopclient0: Add Multi-Arch: same. This fixes: libukui-desktopclient0 could be marked Multi-Arch: same. ([ma-same](https://wiki.debian.org/MultiArch/Hints#ma-same))
* libukui-desktopclient-dev: Add Multi-Arch: same. This fixes: libukui-desktopclient-dev could be marked Multi-Arch: same. ([ma-same](https://wiki.debian.org/MultiArch/Hints#ma-same))
* libukui-fontclient0: Add Multi-Arch: same. This fixes: libukui-fontclient0 could be marked Multi-Arch: same. ([ma-same](https://wiki.debian.org/MultiArch/Hints#ma-same))
* libukui-fontclient-dev: Add Multi-Arch: same. This fixes: libukui-fontclient-dev could be marked Multi-Arch: same. ([ma-same](https://wiki.debian.org/MultiArch/Hints#ma-same))
* libukui-interfaceclient0: Add Multi-Arch: same. This fixes: libukui-interfaceclient0 could be marked Multi-Arch: same. ([ma-same](https://wiki.debian.org/MultiArch/Hints#ma-same))
* libukui-interfaceclient-dev: Add Multi-Arch: same. This fixes: libukui-interfaceclient-dev could be marked Multi-Arch: same. ([ma-same](https://wiki.debian.org/MultiArch/Hints#ma-same))
* libukui-keyboardclient0: Add Multi-Arch: same. This fixes: libukui-keyboardclient0 could be marked Multi-Arch: same. ([ma-same](https://wiki.debian.org/MultiArch/Hints#ma-same))
* libukui-keyboardclient-dev: Add Multi-Arch: same. This fixes: libukui-keyboardclient-dev could be marked Multi-Arch: same. ([ma-same](https://wiki.debian.org/MultiArch/Hints#ma-same))
* libukui-marcogeneralclient0: Add Multi-Arch: same. This fixes: libukui-marcogeneralclient0 could be marked Multi-Arch: same. ([ma-same](https://wiki.debian.org/MultiArch/Hints#ma-same))
* libukui-marcogeneralclient-dev: Add Multi-Arch: same. This fixes: libukui-marcogeneralclient-dev could be marked Multi-Arch: same. ([ma-same](https://wiki.debian.org/MultiArch/Hints#ma-same))
* libukui-mouseclient0: Add Multi-Arch: same. This fixes: libukui-mouseclient0 could be marked Multi-Arch: same. ([ma-same](https://wiki.debian.org/MultiArch/Hints#ma-same))
* libukui-mouseclient-dev: Add Multi-Arch: same. This fixes: libukui-mouseclient-dev could be marked Multi-Arch: same. ([ma-same](https://wiki.debian.org/MultiArch/Hints#ma-same))
* libukui-network0: Add Multi-Arch: same. This fixes: libukui-network0 could be marked Multi-Arch: same. ([ma-same](https://wiki.debian.org/MultiArch/Hints#ma-same))
* libukui-network-dev: Add Multi-Arch: same. This fixes: libukui-network-dev could be marked Multi-Arch: same. ([ma-same](https://wiki.debian.org/MultiArch/Hints#ma-same))
* libukui-powerclient0: Add Multi-Arch: same. This fixes: libukui-powerclient0 could be marked Multi-Arch: same. ([ma-same](https://wiki.debian.org/MultiArch/Hints#ma-same))
* libukui-powerclient-dev: Add Multi-Arch: same. This fixes: libukui-powerclient-dev could be marked Multi-Arch: same. ([ma-same](https://wiki.debian.org/MultiArch/Hints#ma-same))
* libukui-screensaverclient0: Add Multi-Arch: same. This fixes: libukui-screensaverclient0 could be marked Multi-Arch: same. ([ma-same](https://wiki.debian.org/MultiArch/Hints#ma-same))
* libukui-screensaverclient-dev: Add Multi-Arch: same. This fixes: libukui-screensaverclient-dev could be marked Multi-Arch: same. ([ma-same](https://wiki.debian.org/MultiArch/Hints#ma-same))
* libukui-sessionclient0: Add Multi-Arch: same. This fixes: libukui-sessionclient0 could be marked Multi-Arch: same. ([ma-same](https://wiki.debian.org/MultiArch/Hints#ma-same))
* libukui-sessionclient-dev: Add Multi-Arch: same. This fixes: libukui-sessionclient-dev could be marked Multi-Arch: same. ([ma-same](https://wiki.debian.org/MultiArch/Hints#ma-same))
* libukui-subversion0: Add Multi-Arch: same. This fixes: libukui-subversion0 could be marked Multi-Arch: same. ([ma-same](https://wiki.debian.org/MultiArch/Hints#ma-same))
* libukui-subversion-dev: Add Multi-Arch: same. This fixes: libukui-subversion-dev could be marked Multi-Arch: same. ([ma-same](https://wiki.debian.org/MultiArch/Hints#ma-same))
* libukui-sysinfo0: Add Multi-Arch: same. This fixes: libukui-sysinfo0 could be marked Multi-Arch: same. ([ma-same](https://wiki.debian.org/MultiArch/Hints#ma-same))
* libukui-sysinfo-dev: Add Multi-Arch: same. This fixes: libukui-sysinfo-dev could be marked Multi-Arch: same. ([ma-same](https://wiki.debian.org/MultiArch/Hints#ma-same))
* libukui-touchpadclient0: Add Multi-Arch: same. This fixes: libukui-touchpadclient0 could be marked Multi-Arch: same. ([ma-same](https://wiki.debian.org/MultiArch/Hints#ma-same))
* libukui-touchpadclient-dev: Add Multi-Arch: same. This fixes: libukui-touchpadclient-dev could be marked Multi-Arch: same. ([ma-same](https://wiki.debian.org/MultiArch/Hints#ma-same))
* libukui-usersetting0: Add Multi-Arch: same. This fixes: libukui-usersetting0 could be marked Multi-Arch: same. ([ma-same](https://wiki.debian.org/MultiArch/Hints#ma-same))
* libukui-usersetting-dev: Add Multi-Arch: same. This fixes: libukui-usersetting-dev could be marked Multi-Arch: same. ([ma-same](https://wiki.debian.org/MultiArch/Hints#ma-same))
* libukui-xkbgeneralclient0: Add Multi-Arch: same. This fixes: libukui-xkbgeneralclient0 could be marked Multi-Arch: same. ([ma-same](https://wiki.debian.org/MultiArch/Hints#ma-same))
* libukui-xkbgeneralclient-dev: Add Multi-Arch: same. This fixes: libukui-xkbgeneralclient-dev could be marked Multi-Arch: same. ([ma-same](https://wiki.debian.org/MultiArch/Hints#ma-same))

These changes were suggested on https://wiki.debian.org/MultiArch/Hints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/multiarch-fixes).

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/multiarch-fixes/pkg/ukui-interface/a032ebaa-6bb2-41f9-8241-61b555cb538a.


These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/a032ebaa-6bb2-41f9-8241-61b555cb538a/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/a032ebaa-6bb2-41f9-8241-61b555cb538a/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/a032ebaa-6bb2-41f9-8241-61b555cb538a/diffoscope)).
